### PR TITLE
Fix benchmarks to work with Elm 0.19.1

### DIFF
--- a/benchmarks/BenchmarkShared.elm
+++ b/benchmarks/BenchmarkShared.elm
@@ -15,7 +15,7 @@ bigIntHexString =
 
 bigInt : BI.BigInt
 bigInt =
-    BI.fromString bigIntString
+    BI.fromIntString bigIntString
         |> Maybe.withDefault (BI.fromInt 0)
 
 

--- a/benchmarks/FromStringBenchmark.elm
+++ b/benchmarks/FromStringBenchmark.elm
@@ -14,6 +14,6 @@ main =
 suite : Benchmark
 suite =
     describe "fromString"
-        [ benchmark "a 32-digit integer" (\_ -> BI.fromString bigIntString)
+        [ benchmark "a 32-digit integer" (\_ -> BI.fromIntString bigIntString)
         , benchmark "a large hex string" (\_ -> BI.fromHexString bigIntHexString)
         ]

--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -4,27 +4,27 @@
         ".",
         "../src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0",
-            "elm-community/list-extra": "8.0.0",
-            "elm-community/maybe-extra": "5.0.0",
-            "elm-community/result-extra": "2.2.1",
-            "elm-explorations/benchmark": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm-community/list-extra": "8.3.0",
+            "elm-community/maybe-extra": "5.2.0",
+            "elm-community/result-extra": "2.4.0",
+            "elm-explorations/benchmark": "1.0.2",
             "rtfeldman/elm-hex": "1.0.0"
         },
         "indirect": {
-            "BrianHicks/elm-trend": "2.1.2",
-            "Skinney/murmur3": "2.0.8",
-            "elm/browser": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/json": "1.0.0",
-            "elm/regex": "1.0.0",
+            "BrianHicks/elm-trend": "2.1.3",
+            "elm/json": "1.1.3",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "mdgriffith/style-elements": "5.0.1"
+            "mdgriffith/style-elements": "5.0.2",
+            "robinheghan/murmur3": "1.0.0"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
As the title states. Needed to recreate the `elm.json` file by using `elm init` and `elm install` to ensure all dependencies resolved.