### PR TITLE
Update test dependencies to support newer test runner

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,6 @@
     },
     "test-dependencies": {
         "elm/random": "1.0.0 <= v < 2.0.0",
-        "elm-explorations/test": "1.1.0 <= v < 2.0.0"
+        "elm-explorations/test": "2.1.2 <= v < 3.0.0"
     }
 }


### PR DESCRIPTION
Running the latest version of elm-test-rs on this project failed with the following error message:

```
Error: Failed to solve dependencies for tests to run

Caused by:
    This version of elm-test-rs only supports elm-explorations/test 2.0.0 <= v < 3.0.0, but you have 1.1.0 <= v < 2.0.0 in your dependencies
```

The changes in this pull request update the dependencies to enable running tests with the latest version of elm-test-rs Changes in the API of the test framework required adaption of the test code. For details on changes in the test framework, see:

+ https://github.com/elm-explorations/test/commit/e3584bddcbba7030f39dadcd6473469d72f6e372 (https://github.com/elm-explorations/test/pull/46, https://github.com/elm-explorations/test/issues/224)
+ https://github.com/elm-explorations/test/commit/9aa32d9d28435d61d8c53d8b88023dd6c0bdab7e (https://github.com/elm-explorations/test/issues/48)
+ https://github.com/elm-explorations/test/commit/387aa2d6ed53e6389f360529ca01c557a8116289 (https://github.com/elm-explorations/test/pull/157)