### PR TITLE
Improve documentation of modBy

### DIFF
--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -632,6 +632,9 @@ div num den =
 
     modBy (BigInt.fromInt 3) (BigInt.fromInt 3)
 
+**Note:** This function returns negative values when
+the second argument is negative, unlike Basics.modBy.
+
 -}
 modBy : BigInt -> BigInt -> Maybe BigInt
 modBy modulus x =


### PR DESCRIPTION
Closes #4 
Adds comment to `modBy` to note that it does not behave like `Basics.modBy` with negative arguments. 