### PR TITLE
Optimize `modBy` and `div`

### DIFF
--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -721,8 +721,64 @@ the second argument is negative, unlike Basics.modBy.
 
 -}
 modBy : BigInt -> BigInt -> Maybe BigInt
-modBy modulus x =
-    divmod x modulus |> Maybe.map Tuple.second
+modBy den num =
+    if den == zero then
+        Nothing
+
+    else
+        let
+            cand_l =
+                List.length (toDigits num) - List.length (toDigits den) + 1
+
+            m =
+                mod_
+                    (Basics.max 0 cand_l)
+                    (abs num)
+                    (abs den)
+        in
+        Just
+            (mkBigInt (sign num) (magnitude m))
+
+
+mod_ : Int -> BigInt -> BigInt -> BigInt
+mod_ n num den =
+    if n == 0 then
+        modDigit (padDigits n) num den
+
+    else
+        let
+            cmod =
+                modDigit (padDigits n) num den
+        in
+        mod_ (n - 1) cmod den
+
+
+modDigit : BigInt -> BigInt -> BigInt -> BigInt
+modDigit padding x y =
+    modDigit_ (2 ^ maxDigitBits) padding x y
+
+
+modDigit_ : Int -> BigInt -> BigInt -> BigInt -> BigInt
+modDigit_ to_test padding num den =
+    if to_test == 0 then
+        num
+
+    else
+        let
+            x =
+                fromInt to_test
+
+            candidate =
+                mul (mul x den) padding
+
+            newMod =
+                if lte candidate num then
+                    sub num candidate
+
+                else
+                    num
+        in
+        modDigit_ (to_test // 2) padding newMod den
 
 
 {-| Square.

--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -157,6 +157,8 @@ toDigits bigInt =
             ds
 
 
+{-| The base we're using for BigInt, 10^7
+-}
 baseDigit : Int
 baseDigit =
     maxDigitValue + 1

--- a/src/BigInt.elm
+++ b/src/BigInt.elm
@@ -728,18 +728,45 @@ modBy den num =
         Nothing
 
     else
-        let
-            cand_l =
-                List.length (toDigits num) - List.length (toDigits den) + 1
+        case toDigits den of
+            [ shortDen ] ->
+                case num of
+                    Zer ->
+                        Just zero
 
-            m =
-                mod_
-                    (Basics.max 0 cand_l)
-                    (abs num)
-                    (abs den)
-        in
-        Just
-            (mkBigInt (sign num) (magnitude m))
+                    Pos (Magnitude numList) ->
+                        let
+                            m =
+                                List.foldr
+                                    (\d acc -> Basics.modBy shortDen (acc * baseDigit + d))
+                                    0
+                                    numList
+                        in
+                        Just (fromInt m)
+
+                    Neg (Magnitude numList) ->
+                        let
+                            m =
+                                List.foldr
+                                    (\d acc -> Basics.modBy shortDen (acc * baseDigit - d))
+                                    0
+                                    numList
+                        in
+                        Just (fromInt (m - shortDen))
+
+            denList ->
+                let
+                    cand_l =
+                        List.length (toDigits num) - List.length denList + 1
+
+                    m =
+                        mod_
+                            (Basics.max 0 cand_l)
+                            (abs num)
+                            (abs den)
+                in
+                Just
+                    (mkBigInt (sign num) (magnitude m))
 
 
 mod_ : Int -> BigInt -> BigInt -> BigInt

--- a/src/Constants.elm
+++ b/src/Constants.elm
@@ -1,15 +1,16 @@
-module Constants exposing
-    ( hexDigitMagnitude
-    , maxDigitMagnitude
-    , maxDigitValue
-    )
+module Constants exposing (hexDigitMagnitude, maxDigitMagnitude, maxDigitValue)
+
+{-|
+
+@docs hexDigitMagnitude, maxDigitMagnitude, maxDigitValue
+
+-}
+
 
 {-| Seven base-10 digits is the most we can have where x \* x < the JS bigInt limit.
 99999999 > sqrt(MAX\_SAFE\_INTEGER) > 9999999
 A slightly higher number is possible, but would require a major reworking of the string functions.
 -}
-
-
 maxDigitValue : Int
 maxDigitValue =
     -1 + 10 ^ maxDigitMagnitude


### PR DESCRIPTION
Inline the definition of `divmod` to allow for simplifications, plus implement a more efficient algorithm for `modBy` when the modulus is smaller than the 10^7 base